### PR TITLE
Defaults object must be first in ember merge

### DIFF
--- a/addon/mixins/at-who-support.js
+++ b/addon/mixins/at-who-support.js
@@ -13,7 +13,7 @@ export default Ember.Mixin.create({
   defaults: { at: '@' },
 
   calculatedSettings: Ember.computed('settings', 'defaults', function () {
-    return Ember.merge(this.get('settings'), this.get('defaults'));
+    return Ember.merge(this.get('defaults'), this.get('settings'));
   }),
 
   didInsertElement: function () {


### PR DESCRIPTION
if defaults is not first then 'at' will not be overwriten by settings content (if included)
